### PR TITLE
handler: set redirect policy to `none`

### DIFF
--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -123,7 +123,10 @@ fn handle_cache_hit(
 
 lazy_static! {
     /// Lazily loaded HTTP Client that will be used for polling upstream for images.
-    static ref HTTP_CLIENT: reqwest::Client = reqwest::Client::default();
+    static ref HTTP_CLIENT: reqwest::Client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("misconfigured lazy_static http client");
 }
 
 /// A Unit Struct that represents an error where the upstream url is unset in the backend


### PR DESCRIPTION
This will prevent redirects from upstream being streamed to the user, instead it will provide an error response because of an invalid code.

## But Why

In normal use, redirects won't be needed whatsoever. if there are redirects, they either signify that what's being streamed is no longer an image *or* that the upstream client is somehow compromised.