### PR TITLE
feat: chunked stream on cache MISS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ know how to use it, then you should probably stick to using the official client 
 - Customizable TLS setup
 - Battletested & Fast Cache Engine (with compression!1!)
 - HTTP Gzip Support
+- Better streaming of cache `MISS`es
 - Pretty Console Logging
 - Support for JSON & YAML configurations
 - Docker Support / Builds
@@ -47,7 +48,6 @@ know how to use it, then you should probably stick to using the official client 
 - Prometheus / VictoriaMetrics
 - More Cache Engines (like plain filesystem or MongoDB)
 - Non-hardcoded Configuration Path
-- Better streaming of cache `MISS`es
 
 ## Getting Started
 

--- a/src/cache/rocks.rs
+++ b/src/cache/rocks.rs
@@ -3,6 +3,7 @@
 //! Just as a warning, this was written by someone who has never used RocksDB, so some things
 //! probably aren't right (most likely the compaction part).
 
+use super::ImageKey;
 use crate::config::RocksConfig;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -222,22 +223,22 @@ impl RocksCache {
 // For the comments on this trait impl and the functions within, please look at `super::ImageCache`!
 #[async_trait]
 impl super::ImageCache for RocksCache {
-    async fn load(&self, chap_hash: &str, image: &str, saver: bool) -> Option<super::ImageEntry> {
-        self.load_from_db(chap_hash, image, saver)
+    async fn load(&self, key: &ImageKey) -> Option<super::ImageEntry> {
+        self.load_from_db(key.chapter(), key.image(), key.data_saver())
             // log any errors that may occur
             .map_err(|e| {
-                log::error!("db load error: {:?} (for {}/{})", e, chap_hash, image);
+                log::error!("db load error: {:?} (for {})", e, key);
                 e
             })
             .ok()
             .and_then(|x| x)
     }
 
-    async fn save(&self, chap_hash: &str, image: &str, saver: bool, data: Bytes) -> bool {
-        self.save_to_db(chap_hash, image, saver, data)
+    async fn save(&self, key: &ImageKey, data: Bytes) -> bool {
+        self.save_to_db(key.chapter(), key.image(), key.data_saver(), data)
             // log any errors that may occur
             .map_err(|e| {
-                log::error!("db save error: {:?} (for {}/{})", e, chap_hash, image);
+                log::error!("db save error: {:?} (for {})", e, key);
                 e
             })
             .is_ok()

--- a/src/http/chunked.rs
+++ b/src/http/chunked.rs
@@ -1,0 +1,67 @@
+use bytes::{BufMut, Bytes, BytesMut};
+use futures::stream::Stream;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pub(super) type UpstreamStream = dyn Stream<Item = reqwest::Result<Bytes>> + Unpin;
+pub(super) struct ChunkedUpstreamPoll {
+    upstream: Pin<Box<UpstreamStream>>,
+    agg: BytesMut,
+}
+
+impl ChunkedUpstreamPoll {
+    pub(super) fn new(stream: Box<UpstreamStream>, size_hint: usize) -> Self {
+        Self {
+            upstream: Pin::new(stream),
+            agg: BytesMut::with_capacity(size_hint),
+        }
+    }
+}
+
+impl Stream for ChunkedUpstreamPoll {
+    type Item = Result<Bytes, actix_web::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let u = self.upstream.as_mut();
+
+        // poll for upstream stream status
+        match u.poll_next(cx) {
+            // successful upstream poll
+            Poll::Ready(Some(Ok(bytes))) => {
+                self.agg.put(&bytes as &[u8]);
+                Poll::Ready(Some(Ok(bytes)))
+            }
+            // unsuccessful upstream poll
+            Poll::Ready(Some(Err(err))) => {
+                log::warn!("an error occurred while streaming upstream result: {}", err);
+                Poll::Ready(Some(Err(UpstreamError(err).into())))
+            },
+
+            // stream is done, so we should save the cache
+            // TODO: actually save cache
+            Poll::Ready(None) => {
+                log::debug!("stream complete (total = {}b)", self.agg.len());
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// An error type denoting a problem during the stream of the upstream connection.
+///
+/// Can be converted into an `actix_web::Error` as it implemented the `ResponseError` trait.
+#[derive(Debug)]
+struct UpstreamError(reqwest::Error);
+
+impl std::fmt::Display for UpstreamError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(fmt, "{}", self.0)
+    }
+}
+impl std::error::Error for UpstreamError {}
+impl actix_web::ResponseError for UpstreamError {
+    fn status_code(&self) -> actix_web::http::StatusCode {
+        actix_web::http::StatusCode::BAD_GATEWAY
+    }
+}

--- a/src/http/chunked.rs
+++ b/src/http/chunked.rs
@@ -1,19 +1,37 @@
+use crate::{cache::ImageKey, GlobalState};
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::stream::Stream;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 pub(super) type UpstreamStream = dyn Stream<Item = reqwest::Result<Bytes>> + Unpin;
+
+/// A stream to handle cache MISSes by streaming content to the user and saving it until the stream
+/// it complete, then saving it to the cache database.
+///
+/// To break it down: This structure converts a `reqwest` [`Stream`] into an `actix_web` stream,
+/// saving all data to an aggregator, then saving the aggregator to cache once the stream is
+/// completely done.
 pub(super) struct ChunkedUpstreamPoll {
+    gs: Arc<GlobalState>,
     upstream: Pin<Box<UpstreamStream>>,
     agg: BytesMut,
+    cache_key: Arc<ImageKey>,
 }
 
 impl ChunkedUpstreamPoll {
-    pub(super) fn new(stream: Box<UpstreamStream>, size_hint: usize) -> Self {
+    pub(super) fn new(
+        gs: &Arc<GlobalState>,
+        key: ImageKey,
+        stream: Box<UpstreamStream>,
+        size_hint: usize,
+    ) -> Self {
         Self {
+            gs: Arc::clone(gs),
             upstream: Pin::new(stream),
             agg: BytesMut::with_capacity(size_hint),
+            cache_key: Arc::new(key),
         }
     }
 }
@@ -22,29 +40,47 @@ impl Stream for ChunkedUpstreamPoll {
     type Item = Result<Bytes, actix_web::Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // match upstream's stream state and return based on that
         let u = self.upstream.as_mut();
-
-        // poll for upstream stream status
         match u.poll_next(cx) {
             // successful upstream poll
             Poll::Ready(Some(Ok(bytes))) => {
+                // copy new bytes to aggregator and then return value
                 self.agg.put(&bytes as &[u8]);
                 Poll::Ready(Some(Ok(bytes)))
             }
             // unsuccessful upstream poll
-            Poll::Ready(Some(Err(err))) => {
-                log::warn!("an error occurred while streaming upstream result: {}", err);
-                Poll::Ready(Some(Err(UpstreamError(err).into())))
-            },
+            Poll::Ready(Some(Err(e))) => {
+                // internal stream had a problem? return error response
+                log::warn!("error polling upstream image: {}", e);
+                Poll::Ready(Some(Err(UpstreamError(e).into())))
+            }
 
-            // stream is done, so we should save the cache
-            // TODO: actually save cache
+            // stream is done, log and say so
+            // cache save will later be completed in Drop
             Poll::Ready(None) => {
-                log::debug!("stream complete (total = {}b)", self.agg.len());
+                let len = self.agg.len();
+                log::debug!("stream complete (total = {}b)", len);
+
+                // complete saying there is no more data
                 Poll::Ready(None)
             }
+
+            // waiting for next bytes...
             Poll::Pending => Poll::Pending,
         }
+    }
+}
+
+impl Drop for ChunkedUpstreamPoll {
+    /// Schedules a tokio task to save the cache aggregator when this value is dropped
+    fn drop(&mut self) {
+        let bytes = std::mem::take(&mut self.agg).freeze();
+        let gs = Arc::clone(&self.gs);
+        let key = Arc::clone(&self.cache_key);
+        tokio::spawn(async move {
+            gs.cache.save(&key, bytes).await;
+        });
     }
 }
 
@@ -62,6 +98,8 @@ impl std::fmt::Display for UpstreamError {
 impl std::error::Error for UpstreamError {}
 impl actix_web::ResponseError for UpstreamError {
     fn status_code(&self) -> actix_web::http::StatusCode {
+        // since this error occurs if upstream has an error, it can be considered a BAD GATEWAY
+        // problem/code and not the regular INTERNAL SERVER ERROR
         actix_web::http::StatusCode::BAD_GATEWAY
     }
 }

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -163,14 +163,18 @@ async fn start_poll_upstream(
 ) -> Result<UpstreamResponse, Box<dyn std::error::Error>> {
     use std::str::FromStr;
 
-    let upstream = backend.get_upstream().ok_or(NoUpstreamError)?;
-    let url = reqwest::Url::parse(&format!(
-        "{}/{}/{}/{}",
-        &upstream,
-        key.archive_name(),
-        key.chapter(),
-        key.image()
-    ))?;
+    let url = {
+        let upstream = backend.get_upstream().ok_or(NoUpstreamError)?;
+        let base_url = reqwest::Url::parse(&upstream)?;
+        reqwest::Url::options()
+            .base_url(Some(&base_url))
+            .parse(&format!(
+                "{}/{}/{}",
+                key.archive_name(),
+                key.chapter(),
+                key.image()
+            ))?
+    };
 
     let res = HTTP_CLIENT.get(url).send().await?;
     let status = res.status();

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -250,8 +250,5 @@ async fn handle_cache_miss(
         .append_header(header::ContentType(res.content_type))
         .append_header(header::LastModified(res.last_modified))
         .append_header(("X-Cache", "MISS"));
-    if let Some(size_hint) = res.size_hint {
-        http_res.append_header(("Content-Length", size_hint));
-    }
     http_res.streaming(chunked)
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -10,6 +10,7 @@ use std::io;
 use std::sync::{atomic, Arc};
 
 mod handler;
+mod chunked;
 
 #[derive(serde::Deserialize)]
 struct MdPathArgs {


### PR DESCRIPTION
# Implements

- A Stream type that will stream the upstream bytes to the client as they come in instead of all at once after a download is completed. This should be much faster as it's upload while download instead of upload after download.
- A `ImageKey` structure for easily passing a key that can be used to perform cache operations. This key contains the three elements: the chapter hash, the image path, and whether it's data saver.