### PR TITLE
tweak(build): add rocksdb ce as a build feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,6 @@ dependencies = [
  "brotli2",
  "bytes",
  "bytestring",
- "cookie",
  "derive_more",
  "encoding_rs",
  "flate2",
@@ -450,17 +449,6 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "cookie"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
-dependencies = [
- "percent-encoding",
- "time 0.2.26",
- "version_check",
-]
 
 [[package]]
 name = "core-foundation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,11 @@ description = "Yet another unofficial MD@Home client implementation"
 readme = "README.md"
 license = "MIT"
 
+[features]
+default = ["ce-rocksdb"]
+ce-rocksdb = ["rocksdb"]
+
 [dependencies]
-actix-web = {version = "4.0.0-beta.5", features = ["openssl"]}
 ctrlc = {version = "3.1.8", features = ["termination"]}
 reqwest = {version = "0.11.2", features = ["json", "stream"]}
 bytes = {version = "1.0.1", features = ["serde"]}
@@ -34,9 +37,15 @@ lazy_static = "1.4.0"
 version = "1.4.0"
 features = ["rt", "rt-multi-thread", "macros", "fs", "io-util", "time"]
 
+[dependencies.actix-web]
+version = "4.0.0-beta.5"
+default-features = false
+features = ["openssl", "compress"]
+
 [dependencies.rocksdb]
 version = "0.15.0"
 default-features = false
+optional = true
 features = ["zstd"]
 
 [profile.release]

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -4,7 +4,9 @@ use bytes::Bytes;
 // re-export different caches
 // mod fs;
 // pub use fs::FileSystemCache;
+#[cfg(feature = "ce-rocksdb")]
 mod rocks;
+#[cfg(feature = "ce-rocksdb")]
 pub use rocks::RocksCache;
 
 /// A basic type representing an image in cache. First value represents the bytes and second value

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,11 +36,14 @@ struct Application {
 /// This function will panic if the configured cache engine is invalid or wrong, or if there is a
 /// problem creating the cache implementation.
 fn create_dyn_cache(config: &config::AppConfig) -> Box<dyn cache::ImageCache> {
-    Box::new(match config.cache_engine.as_str() {
-        "rocksdb" => cache::RocksCache::new(&config.rocks_opt)
-            .expect("unable to initialize RocksDB cache engine"),
+    match config.cache_engine.as_str() {
+        #[cfg(feature = "ce-rocksdb")]
+        "rocksdb" => Box::new(
+            cache::RocksCache::new(&config.rocks_opt)
+                .expect("unable to initialize RocksDB cache engine"),
+        ),
         a => panic!("\"{}\" is not a valid cache engine", a),
-    })
+    }
 }
 
 impl Application {


### PR DESCRIPTION
In the future, this will be applied to all supported cache instances. This will allow building the client with only the features you need, saving on space and possibly performance.