### PR TITLE
feat: RocksDB Optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ features = ["openssl", "compress"]
 version = "0.15.0"
 default-features = false
 optional = true
-features = ["zstd"]
+features = []
 
 [profile.release]
 opt-level = 3

--- a/settings.sample.yaml
+++ b/settings.sample.yaml
@@ -23,20 +23,16 @@ rocksdb_options:
     path: ./cache
     # The number of threads that RocksDB will use in the background for flushing and compaction
     # It is recommended to set this to the number of system threads you have
-    parallelism: 4
-    # This will compress database files on disk and will lead to a smaller database. However, it
-    # will use more CPU when performing writes.
-    zstd_compression: true
-    # This will optimize compactions on the database. It is recommended to keep this on unless
-    # you have a low memory machine. If you do have a low memory machine, do some testing.
-    optimize_compaction: true
-    # The rate limit of writing to the disk in mebibytes/s. This will smooth out disk writes but will
-    # use up more RAM in the process.
-    # 0 will disable the rate limiter (so IOs won't be smoothed out)
-    write_rate_limit: 0
+    # Default is 2
+    #parallelism: 2
     # The in-memory write buffer size in mebibytes. Increasing this will generally increase performance
     # of bulk writes with the cost of using more RAM. (128MiB = ~1GB of RAM at peak)
-    write_buffer_size: 128
+    # Default is 64MiB
+    #write_buffer_size: 64
+    # The rate limit of writing to the disk in mebibytes/s. This will smooth out disk writes but will
+    # use up more RAM in the process.
+    # Default is off
+    #write_rate_limit: 24
 
 
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -2,8 +2,8 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
-use std::time;
 use std::sync::Arc;
+use std::time;
 
 // re-export different caches
 // mod fs;
@@ -28,7 +28,7 @@ struct ImageKeyInner {
 /// This data structure allows for shallow cloning that won't copy any actual memory
 #[derive(Debug, Clone)]
 pub struct ImageKey {
-    inner: Arc<ImageKeyInner>
+    inner: Arc<ImageKeyInner>,
 }
 
 impl ImageKey {
@@ -38,8 +38,8 @@ impl ImageKey {
             inner: Arc::new(ImageKeyInner {
                 chapter,
                 image,
-                data_saver
-            })
+                data_saver,
+            }),
         }
     }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -3,6 +3,7 @@ use bytes::Bytes;
 use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
 use std::time;
+use std::sync::Arc;
 
 // re-export different caches
 // mod fs;
@@ -12,24 +13,33 @@ mod rocks;
 #[cfg(feature = "ce-rocksdb")]
 pub use rocks::RocksCache;
 
+#[derive(Debug)]
+struct ImageKeyInner {
+    chapter: String,
+    image: String,
+    data_saver: bool,
+}
+
 /// A data structure that represents the three components of an image path:
 /// - The Chapter Hash
 /// - The Image Name
 /// - Whether it's `data` or `data-saver`
+///
+/// This data structure allows for shallow cloning that won't copy any actual memory
 #[derive(Debug, Clone)]
 pub struct ImageKey {
-    chapter: String,
-    image: String,
-    data_saver: bool,
+    inner: Arc<ImageKeyInner>
 }
 
 impl ImageKey {
     /// Creates a new [`ImageKey`] instance using the provided `String`s
     pub fn new(chapter: String, image: String, data_saver: bool) -> Self {
         Self {
-            chapter,
-            image,
-            data_saver,
+            inner: Arc::new(ImageKeyInner {
+                chapter,
+                image,
+                data_saver
+            })
         }
     }
 
@@ -49,17 +59,17 @@ impl ImageKey {
     /// Retrieves the chapter hash associated with the key
     #[inline]
     pub fn chapter(&self) -> &str {
-        &self.chapter
+        &self.inner.chapter
     }
     /// Retrieves the file associated with the key
     #[inline]
     pub fn image(&self) -> &str {
-        &self.image
+        &self.inner.image
     }
     /// Retrieves if the key is data saver or not
     #[inline]
     pub fn data_saver(&self) -> bool {
-        self.data_saver
+        self.inner.data_saver
     }
 
     /// Returns a string representation of `data_saver`

--- a/src/cache/rocks.rs
+++ b/src/cache/rocks.rs
@@ -8,16 +8,21 @@ use crate::config::RocksConfig;
 use async_trait::async_trait;
 use bytes::Bytes;
 use std::convert::TryInto;
+use std::sync::Arc;
 
 /// Cache implementation for an on-disk RocksDB cache
+///
+/// This structure allows for shallow copying that points to the same database
+#[derive(Clone)]
 pub struct RocksCache {
-    db: rocksdb::DB,
+    db: Arc<rocksdb::DB>,
 }
 
 #[derive(Debug)]
 pub enum CacheError {
     Rocks(rocksdb::Error),
     Bincode(bincode::Error),
+    Async(tokio::task::JoinError),
 }
 
 impl RocksCache {
@@ -75,7 +80,7 @@ impl RocksCache {
             rocksdb::DB::open_cf_descriptors(&db_opts, &cfg.path, vec![image_cf])?
         };
 
-        Ok(Self { db })
+        Ok(Self { db: Arc::new(db) })
     }
 
     /// Calculates a predicatable unqiue key for the chap_hash, image, saver combo
@@ -100,10 +105,7 @@ impl RocksCache {
             .unwrap()
     }
 
-    /// Saves an images bytes to the database along
-    ///
-    /// In addition, saves a checksum and the time it was put in the database for verifying bytes
-    /// on load and shrinking the database by oldest
+    /// Syncronously saves an image and additional information to the RocksDB database.
     pub fn save_to_db(
         &self,
         key: &ImageKey,
@@ -124,11 +126,34 @@ impl RocksCache {
             .map_err(CacheError::Rocks)
     }
 
+    /// Async version of [`save_to_db`]
+    ///
+    /// All work is pushed off to [`tokio`]'s task scheduler so this operation will be spawned on
+    /// another thread and won't block
+    pub async fn save_to_db_async(
+        &self,
+        key: &ImageKey,
+        mime_type: String,
+        data: Bytes,
+    ) -> Result<(), CacheError> {
+        // both copies are shallow, no memory is actually copied
+        let this = self.clone();
+        let key = key.clone();
+
+        // spawn a blocking task, which means this long DB op will be pushed off to tokio's task
+        // handler and executed on a different thread.
+        let result =
+            tokio::task::spawn_blocking(move || this.save_to_db(&key, mime_type, data)).await;
+
+        // map the error into the correct format and return
+        result.map_err(CacheError::Async).and_then(|x| x)
+    }
+
     /// Loads the bytes of an image and the timestamp it was originally saved from the database
     /// that correspond to the chapter, image, and archive type provided.
     ///
     /// Result provides if any errors happen, and Option provides if the key matched.
-    pub fn load_from_db(&self, key: &ImageKey) -> Result<Option<super::ImageEntry>, CacheError> {
+    pub fn load_from_db(&self, key: &ImageKey) -> Result<Option<ImageEntry>, CacheError> {
         // find the bytes in the database (converting Vec<u8> to Bytes)
         let db_bytes = {
             let image_cf = self.get_image_cf();
@@ -146,6 +171,26 @@ impl RocksCache {
         } else {
             None
         })
+    }
+
+    /// Async version of [`load_from_db`]
+    ///
+    /// All work is pushed off to [`tokio`]'s task scheduler so this operation will be spawned on
+    /// another thread and won't block
+    pub async fn load_from_db_async(
+        &self,
+        key: &ImageKey,
+    ) -> Result<Option<ImageEntry>, CacheError> {
+        // both copies are shallow, no memory is actually copied
+        let this = self.clone();
+        let key = key.clone();
+
+        // spawn a blocking task, which means this long DB op will be pushed off to tokio's task
+        // handler and executed on a different thread.
+        let result = tokio::task::spawn_blocking(move || this.load_from_db(&key)).await;
+
+        // map the error into the correct format and return
+        result.map_err(CacheError::Async).and_then(|x| x)
     }
 
     /// Approximate size of the database on the disk, according to RockDB's list of live files
@@ -182,24 +227,11 @@ impl RocksCache {
 #[async_trait]
 impl super::ImageCache for RocksCache {
     async fn load(&self, key: &ImageKey) -> Option<ImageEntry> {
-        self.load_from_db(key)
-            // log any errors that may occur
-            .map_err(|e| {
-                log::error!("db load error: {:?} (for {})", e, key);
-                e
-            })
-            .ok()
-            .and_then(|x| x)
+        self.load_from_db_async(key).await.ok().and_then(|x| x)
     }
 
     async fn save(&self, key: &ImageKey, mime_type: String, data: Bytes) -> bool {
-        self.save_to_db(key, mime_type, data)
-            // log any errors that may occur
-            .map_err(|e| {
-                log::error!("db save error: {:?} (for {})", e, key);
-                e
-            })
-            .is_ok()
+        self.save_to_db_async(key, mime_type, data).await.is_ok()
     }
 
     fn report(&self) -> u64 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,11 +36,19 @@ pub struct AppConfig {
 #[derive(Deserialize, Debug)]
 pub struct RocksConfig {
     pub path: String,
-    pub parallelism: u16,
-    pub zstd_compression: bool,
-    pub optimize_compaction: bool,
-    pub write_rate_limit: usize,
+    #[serde(default = "parallelism_default")]
+    pub parallelism: i32,
+    #[serde(default = "write_buf_sz_default")]
     pub write_buffer_size: usize,
+    pub write_rate_limit: Option<usize>,
+}
+#[inline]
+fn parallelism_default() -> i32 {
+    2
+}
+#[inline]
+fn write_buf_sz_default() -> usize {
+    64
 }
 
 /// Various different errors that could happen when opening or parsing a configuration file.


### PR DESCRIPTION
This PR includes multiple changes (including breaking) for the RocksDB cache engine:

- Load/Save operations have are now async with `tokio::task::spawn_blocking` APIs
- LRU, Bloom Filter, and other optimizations for database options
- Changes to client configuration
    - `parallelism` option is optional with default of `2` threads
    - `zstd_compression` compression has been removed, as it won't do much and is just slow
    - `optimize_compaction` option has been removed and is enabled by default
    - `write_buffer_size` option is optional with default of `64`MiB
    - `write_rate_limit` is now disabled by removing the option instead of setting it to `0`

## Fixes

This PR fixes cache stalls with RocksDB because of synchronous calls

Fixes #10 

## Improvements

Subtle improvements for database performance has been implemented because of LRU and Bloom Filter implementation.