### PR TITLE
Add `fs` Cache Engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,25 @@ jobs:
                   command: test
 
     build:
-        name: Build
+        name: Build ${{ matrix.name }}
         needs: [lint, test]
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                name:
+                    - ce-filesystem
+                    - ce-rocksdb
+                    - all-features
+                include:
+                    - name: ce-filesystem
+                      build_flags: --features ce-filesystem
+                    - name: ce-rocksdb
+                      build_flags: --features ce-rocksdb
+                    - name: all-features
+                      build_flags: --all-features
+        env:
+            RUSTFLAGS: -C link-args=-s
+
         steps:
             - uses: actions/checkout@v2
 
@@ -131,10 +147,13 @@ jobs:
               uses: actions-rs/cargo@v1
               with:
                   command: build
-                  args: --release
+                  args: |
+                      --release
+                      --no-default-features
+                      ${{ matrix.build_flags || '' }}
             - uses: actions/upload-artifact@v2
               with:
-                  name: ${{ runner.os }}-scalpel
+                  name: scalpel-${{ matrix.name }}
                   path: target/release/scalpel*
 
 # TODO: Add build for windows systems

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.3",
  "regex",
  "serde",
  "sha-1",
@@ -213,7 +213,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.2",
  "once_cell",
  "version_check",
 ]
@@ -331,10 +331,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bson"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b6553abdb9d2d8f262f0b5bccf807321d5b7d1a12796bcede8e1f150e85f2e"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "lazy_static",
+ "linked-hash-map",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -446,6 +469,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +582,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "forceps"
+version = "0.2.1"
+source = "git+https://github.com/blockba5her/forceps?branch=main#19ff90283c63acdc39a2d3a9d81c9c9fca829071"
+dependencies = [
+ "async-trait",
+ "bson",
+ "bytes",
+ "hex",
+ "md5",
+ "rand 0.8.3",
+ "serde",
+ "sled",
+ "tokio",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +620,16 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -652,6 +725,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,13 +745,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -973,6 +1066,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "memoffset"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,14 +1354,37 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
+ "rand_hc 0.3.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1269,7 +1394,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1278,7 +1412,16 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.2",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1287,7 +1430,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1402,6 +1545,7 @@ dependencies = [
  "chrono",
  "ctrlc",
  "env_logger",
+ "forceps",
  "futures",
  "hex",
  "lazy_static",
@@ -1498,6 +1642,7 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -1566,6 +1711,22 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "sled"
+version = "0.34.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d0132f3e393bcb7390c60bb45769498cf4550bcb7a21d7f95c02b69f6362cdc"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot",
+]
 
 [[package]]
 name = "smallvec"
@@ -1671,7 +1832,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
  "libc",
- "rand",
+ "rand 0.8.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -1693,7 +1854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -1892,6 +2053,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +2079,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ readme = "README.md"
 license = "MIT"
 
 [features]
-default = ["ce-rocksdb"]
+default = ["ce-rocksdb", "ce-filesystem"]
 ce-rocksdb = ["rocksdb"]
+ce-filesystem = ["forceps"]
 
 [dependencies]
 ctrlc = {version = "3.1.8", features = ["termination"]}
@@ -46,7 +47,11 @@ features = ["openssl", "compress"]
 version = "0.16.0"
 default-features = false
 optional = true
-features = []
+
+[dependencies.forceps]
+git = "https://github.com/blockba5her/forceps"
+branch = "main"
+optional = true
 
 [profile.release]
 opt-level = 3

--- a/settings.sample.yaml
+++ b/settings.sample.yaml
@@ -14,8 +14,18 @@ max_grace_period: 60
 # The minimum is 40GiB (40960), otherwise program will panic
 cache_size_mebibytes: 40960
 
-# Only "rocksdb" for now, in the future will include other engines
-cache_engine: rocksdb
+# "fs" = A basic filesystem cache that includes the essentials
+# "rocksdb" = The RocksDB-powered cache engine that is highly customizable
+cache_engine: fs
+
+# Configuration for the "fs" cache engine. Only required if engine is fs.
+fs_options:
+    # Self explanatory
+    path: ./cache
+    # KiB allocated for the in-memory read-write buffer
+    # This generally is a good number except for very specific workloads
+    # Default is 16KiB
+    #rw_buffer_size: 16
 
 # Configuration for "rocksdb" cache engine. Only required if engine is rocksdb
 rocksdb_options:
@@ -33,7 +43,6 @@ rocksdb_options:
     # use up more RAM in the process.
     # Default is off
     #write_rate_limit: 24
-
 
 
 ### HTTP CONFIGURATION ###

--- a/src/cache/fs.rs
+++ b/src/cache/fs.rs
@@ -1,88 +1,152 @@
-//! This is incomplete, please look at `rocks.rs` instead
+use super::{ImageCache, ImageEntry, ImageKey};
+use bytes::Bytes;
+use std::convert::TryInto;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time;
 
-use super::ImageCache;
-use std::{io, path};
-use tokio::fs;
+/// Time since epoch in milliseconds
+#[inline]
+fn now_as_millis() -> u64 {
+    time::SystemTime::now()
+        .duration_since(time::UNIX_EPOCH)
+        .map(|x| x.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[derive(Debug)]
+pub enum CacheError {
+    Forceps(forceps::Error),
+    Bincode(bincode::Error),
+}
 
 pub struct FileSystemCache {
-    base: path::PathBuf
+    cache: forceps::Cache,
+
+    /// timestamp of last full size fetch (millis since epoch)
+    last_fetch: AtomicU64,
+    /// total db bytes counter
+    total: AtomicU64,
 }
 
 impl FileSystemCache {
-    /// Find the full path including the base directory of an image on the disk.
-    ///
-    /// **WARNING**: This does not verify that the image exists on the disk, it only specifies where
-    /// it should exist.
-    fn get_path(&self, chap_hash: &str, image: &str, saver: bool) -> path::PathBuf {
-        // find the chapter segment of the path
-        //
-        // Example: if chapter was "8172a46adc798f4f4ace6663322a383e" then the path would end up
-        // being "81/72/8172a46adc798f4f4ace6663322a383e/IMG.png"
-        let chap_path = format!("{}/{}/{}", &chap_hash[0..2], &chap_hash[2..4], chap_hash);
+    pub async fn new() -> Result<Self, CacheError> {
+        let cache = forceps::Cache::new("./cache")
+            .read_write_buffer(16 * 1024)
+            .build()
+            .await
+            .map_err(CacheError::Forceps)?;
 
-        // clone the base path then push relative path to image
-        let mut full_path = self.base.clone();
-        full_path.push(if saver {
-            format!("{}/saver-{}", chap_path, image)
-        } else {
-            format!("{}/{}", chap_path, image)
-        });
-        full_path
-    }
-
-    /// Create a new [`FileSystemCache`](Self) instance, automatically creating the path if it
-    /// doesn't exist in the meantime.
-    ///
-    /// This will fail if the base path provided is a file instead of a directory, or if there is
-    /// some other io Error (like an error reading metadata because of permission levels)
-    pub async fn new(base: impl AsRef<path::Path>) -> io::Result<Self> {
-        // find the metadata of the path, creating if it doesn't exist already
-        let meta = match fs::metadata(&base).await {
-            // metadata found, so immediately return that
-            Ok(m) => m,
-
-            Err(e) => match e.kind() {
-                // if folder not found, create it and refind metadata
-                io::ErrorKind::NotFound => {
-                    fs::create_dir_all(&base).await?;
-                    fs::metadata(&base).await?
-                }
-
-                // other errors are unexpected and can just pass up the stack
-                _ => return Err(e)
-            }
+        let s = Self {
+            cache,
+            last_fetch: AtomicU64::new(now_as_millis()),
+            total: AtomicU64::new(0),
         };
-
-        // if it's not a directory then return an error
-        // this error is the same as if you were to open try to open a file but it was actually a
-        // directory (at least on windows)
-        if !meta.is_dir() {
-            return Err(io::ErrorKind::PermissionDenied.into());
-        }
-
-        Ok(Self {
-            base: base.as_ref().into()
-        })
+        s.update_real_size();
+        Ok(s)
     }
 
-    pub async fn save_on_disk(&self, chap_hash: &str, image: &str, buf: &[u8]) -> io::Result<()> {
-        // TODO: don't hardcode saver
-        let path = self.get_path(chap_hash, image, false);
+    /// Updates the internally kept database total bytes counter to the actual database value. This
+    /// function is costly as it does an entire iteration over the database metadata.
+    fn update_real_size(&self) -> u64 {
+        let sz = self.cache.metadata_iter().fold(0u64, |acc, x| match x {
+            Ok((_, meta)) => acc + meta.get_size(),
+            _ => acc,
+        });
+        self.total.store(sz, Ordering::SeqCst);
+        sz
+    }
 
-        // create directory up to file if it doesn't exist
-        if let Some(p) = path.parent() {
-            fs::create_dir_all(p).await?;
+    /// Finds an estimated total size of the database. If a certain amount of time has passed, then
+    /// it will find the real size and update the internal counter.
+    fn find_size(&self) -> u64 {
+        // 1 hr in milliseconds
+        const MIN_TIME: u64 = 1000 * 60 * 60;
+        let last_fetch = self.last_fetch.load(Ordering::Relaxed);
+        let now = now_as_millis();
+
+        // if it's been over an hour since the last fetch, then fetch again and update `last_fetch`
+        // to the correct value
+        if now - last_fetch >= MIN_TIME {
+            self.update_real_size();
+            self.last_fetch.store(now, Ordering::SeqCst);
         }
 
-        let mut f = fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(path)
-            .await?;
+        self.total.load(Ordering::SeqCst)
+    }
 
-        use tokio::io::AsyncWriteExt;
-        f.write_all(buf).await?;
+    /// Reads an entry from the database based on the key provided
+    async fn read_from_db(&self, key: &ImageKey) -> Result<ImageEntry, CacheError> {
+        let bytes = self
+            .cache
+            .read(key.as_bkey())
+            .await
+            .map_err(CacheError::Forceps)?;
+        let e: ImageEntry = bytes.try_into().map_err(CacheError::Bincode)?;
+        Ok(e)
+    }
 
+    /// Writes an entry to the database and returns the error that occurs
+    async fn save_to_db(
+        &self,
+        key: &ImageKey,
+        mime_type: String,
+        data: Bytes,
+    ) -> Result<(), CacheError> {
+        let entry = ImageEntry::new_assume(data, mime_type);
+        let ser_bytes: Bytes = entry.try_into().map_err(CacheError::Bincode)?;
+        self.cache
+            .write(key.as_bkey(), &ser_bytes)
+            .await
+            .map_err(CacheError::Forceps)?;
+
+        // update the total size counter with the new storage value
+        self.total
+            .fetch_add(ser_bytes.len() as u64, Ordering::SeqCst);
         Ok(())
     }
 }
+
+#[async_trait::async_trait]
+impl ImageCache for FileSystemCache {
+    async fn load(&self, key: &ImageKey) -> Option<ImageEntry> {
+        let res = self.read_from_db(key).await;
+        match &res {
+            Err(CacheError::Forceps(forceps::Error::NotFound)) => {}
+            Err(e) => log::error!("error reading data from db: {}", e),
+            _ => {}
+        }
+        res.ok()
+    }
+    async fn save(&self, key: &ImageKey, mime_type: String, data: Bytes) -> bool {
+        if let Err(e) = self.save_to_db(key, mime_type, data).await {
+            log::error!("error writing data to db: {}", e);
+            false
+        } else {
+            true
+        }
+    }
+
+    fn report(&self) -> u64 {
+        self.find_size()
+    }
+
+    async fn shrink(&self, min: u64) -> Result<u64, ()> {
+        use forceps::evictors::FifoEvictor;
+
+        if let Err(e) = self.cache.evict_with(FifoEvictor::new(min)).await {
+            log::error!("error shrinking db occured: {}", CacheError::Forceps(e));
+            return Err(());
+        }
+        Ok(self.update_real_size())
+    }
+}
+
+impl std::fmt::Display for CacheError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Forceps(e) => write!(fmt, "ce-filesystem/forceps - \"{}\"", e),
+            Self::Bincode(e) => write!(fmt, "ce-filesystem/bincode - \"{}\"", e),
+        }
+    }
+}
+impl std::error::Error for CacheError {}

--- a/src/cache/fs.rs
+++ b/src/cache/fs.rs
@@ -1,4 +1,5 @@
 use super::{ImageCache, ImageEntry, ImageKey};
+use crate::config::FsConfig;
 use bytes::Bytes;
 use std::convert::TryInto;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -29,9 +30,9 @@ pub struct FileSystemCache {
 }
 
 impl FileSystemCache {
-    pub async fn new() -> Result<Self, CacheError> {
-        let cache = forceps::Cache::new("./cache")
-            .read_write_buffer(16 * 1024)
+    pub async fn new(config: &FsConfig) -> Result<Self, CacheError> {
+        let cache = forceps::Cache::new(&config.path)
+            .read_write_buffer(config.rw_buffer_size * 1024)
             .build()
             .await
             .map_err(CacheError::Forceps)?;

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -6,8 +6,11 @@ use std::sync::Arc;
 use std::time;
 
 // re-export different caches
-// mod fs;
-// pub use fs::FileSystemCache;
+#[cfg(feature = "ce-filesystem")]
+mod fs;
+#[cfg(feature = "ce-filesystem")]
+pub use fs::FileSystemCache;
+
 #[cfg(feature = "ce-rocksdb")]
 mod rocks;
 #[cfg(feature = "ce-rocksdb")]
@@ -80,6 +83,18 @@ impl ImageKey {
         } else {
             "data"
         }
+    }
+
+    /// Calculates a predicatable unqiue key for the chap_hash, image, saver combo
+    ///
+    /// Essentially calculates the md5 hash of the chapter hash and image name together, taking
+    /// into account if the image is data-saver
+    pub fn as_bkey(&self) -> Md5Bytes {
+        let mut ctx = md5::Context::new();
+        ctx.consume([self.data_saver() as u8]);
+        ctx.consume(self.chapter());
+        ctx.consume(self.image());
+        ctx.compute().into()
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,9 @@ pub struct AppConfig {
     pub cache_size_mebibytes: u32,
     pub cache_engine: String,
     #[serde(rename = "rocksdb_options")]
-    pub rocks_opt: RocksConfig,
+    pub rocks_opt: Option<RocksConfig>,
+    #[serde(rename = "fs_options")]
+    pub fs_opt: Option<FsConfig>,
 
     // webserver settings
     pub port: u16,
@@ -36,19 +38,30 @@ pub struct AppConfig {
 #[derive(Deserialize, Debug)]
 pub struct RocksConfig {
     pub path: String,
-    #[serde(default = "parallelism_default")]
+    #[serde(default = "rocksce_parallelism")]
     pub parallelism: i32,
-    #[serde(default = "write_buf_sz_default")]
+    #[serde(default = "rocksce_write_buf_sz")]
     pub write_buffer_size: usize,
     pub write_rate_limit: Option<usize>,
 }
 #[inline]
-fn parallelism_default() -> i32 {
+fn rocksce_parallelism() -> i32 {
     2
 }
 #[inline]
-fn write_buf_sz_default() -> usize {
+fn rocksce_write_buf_sz() -> usize {
     64
+}
+
+/// Configuration for FileSystem cache engine
+#[derive(Deserialize, Debug)]
+pub struct FsConfig {
+    pub path: String,
+    #[serde(default = "fsce_rw_buf_sz")]
+    pub rw_buffer_size: usize,
+}
+fn fsce_rw_buf_sz() -> usize {
+    16
 }
 
 /// Various different errors that could happen when opening or parsing a configuration file.


### PR DESCRIPTION
This implements a filesystem cache engine that can be optionally built with the binary through features. It is included in the binary build by default (included in default features).

The backend uses [`blockba5her/forcpes`](https://github.com/blockba5her/forceps) for the database.

Fixes #12