### PR TITLE
Fix conversion number in backend ping

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -127,7 +127,7 @@ impl Backend {
                 network_speed: self
                     .config
                     .external_max_speed
-                    .map(|x| x as u64 * 1024 / 8)
+                    .map(|x| x as u64 * 1000 / 8)
                     .unwrap_or(0),
                 build_version: c::SPEC,
                 ip_address: self.config.external_ip.clone(),


### PR DESCRIPTION
The `external_max_speed` was being converted as if it were a kibibit value, however it is documented as a kilobit number.

This wouldn't have caused too much of a difference, however it's still present.