### PR TITLE
Less String Clones

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,6 +1,6 @@
 use crate::config::AppConfig;
 use crate::utils::constants as c;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, RwLockReadGuard};
 
 // below are structures that represent JSON objects for passing messages to and from the server
 //
@@ -252,8 +252,7 @@ impl Backend {
 
     /// Returns the upstream url stored from the API. Returns `None` if there has been no
     /// successful ping yet, and `Some` containing the upstream URL as provided up the API.
-    pub fn get_upstream(&self) -> Option<String> {
-        let inner = self.upstream_url.read().unwrap();
-        inner.clone()
+    pub fn get_upstream(&self) -> RwLockReadGuard<Option<String>> {
+        self.upstream_url.read().unwrap()
     }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -43,19 +43,6 @@ impl ImageKey {
         }
     }
 
-    /// Converts `str`-like parameters into `String`s then creates the new structure
-    pub fn from_str_like<C: AsRef<str>, I: AsRef<str>>(
-        chapter: C,
-        image: I,
-        data_saver: bool,
-    ) -> Self {
-        Self::new(
-            String::from(chapter.as_ref()),
-            String::from(image.as_ref()),
-            data_saver,
-        )
-    }
-
     /// Retrieves the chapter hash associated with the key
     #[inline]
     pub fn chapter(&self) -> &str {

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -152,12 +152,14 @@ async fn start_poll_upstream(
     use std::str::FromStr;
 
     let url = {
-        let upstream = backend.get_upstream().ok_or(NoUpstreamError)?;
-        let base_url = reqwest::Url::parse(&upstream)?;
+        let upstream_guard = backend.get_upstream();
+        let upstream = upstream_guard.as_ref().ok_or(NoUpstreamError)?;
+
+        let base_url = reqwest::Url::parse(upstream)?;
         reqwest::Url::options()
             .base_url(Some(&base_url))
             .parse(&format!(
-                "{}/{}/{}",
+                "/{}/{}/{}",
                 key.archive_name(),
                 key.chapter(),
                 key.image()

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -81,7 +81,8 @@ async fn md_service(
     gs.request_counter.fetch_add(1, atomic::Ordering::Relaxed);
 
     // respond using CacheResponder, which will handle cache HITs and MISSes
-    let cache_key = ImageKey::from_str_like(&path.chap_hash, &path.image, saver);
+    let args = path.into_inner();
+    let cache_key = ImageKey::new(args.chap_hash, args.image, saver);
     Ok(handler::response_from_cache(&peer_addr, &req, &gs, cache_key).await)
 }
 


### PR DESCRIPTION
Instances of string cloning on each request have been removed:

- Cloning path parameters into `ImageKey` is now a move
- Upstream URL is now returned as a `RwLockReadGuard` instead of a cloned string