### PR TITLE
Negative max_grace_period

### DIFF
--- a/settings.sample.yaml
+++ b/settings.sample.yaml
@@ -4,7 +4,9 @@
 client_secret: "YOUR CLIENT SECRET"
 
 # The max number of seconds that the graceful shutdown is allowed to take.
-# 0 would mean that graceful shutdown will take as long as it wants
+# <0 = Graceful shutdown will be skipped
+# =0 = Graceful shutdown will have no time limit
+# >0 = Is the maximum number of seconds graceful shutdowns can last
 max_grace_period: 60
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use tokio::fs;
 pub struct AppConfig {
     // basic client configuration
     pub client_secret: String,
-    pub max_grace_period: u64,
+    pub max_grace_period: i32,
     #[serde(default)]
     pub skip_tokens: bool,
 


### PR DESCRIPTION
Allow `max_grace_period` to be negative.

If the setting is negative, it will completely skip the graceful shutdown period. Documentation in the `settings.sample.yaml` has also been updated accordingly.