### PR TITLE
Init changes for HttpServer

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -131,7 +131,7 @@ fn spawn_http_server(
             .wrap(
                 middleware::DefaultHeaders::new()
                     // Advertisement Headers
-                    .header("Server", server_info.clone())
+                    .header("Server", &server_info)
                     .header("X-Powered-By", "Actix Web")
                     .header("X-Version", c::VERSION)
                     // Headers required by client spec
@@ -150,6 +150,9 @@ fn spawn_http_server(
             .route(
                 "/{archive_type}/{chap_hash}/{image}", // untokenized route
                 web::get().to(md_service),
+            )
+            .default_service(
+                web::route().to(|| HttpResponse::NotFound().body("no valid route found")),
             )
     })
     .keep_alive(gs.config.keep_alive)

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -139,7 +139,11 @@ fn spawn_http_server(
                     .header("Access-Control-Allow-Origin", "https://mangadex.org")
                     .header("Access-Control-Expose-Headers", "*")
                     .header("Cache-Control", "public, max-age=1209600")
-                    .header("Timing-Allow-Origin", "https://mangadex.org"),
+                    .header("Timing-Allow-Origin", "https://mangadex.org")
+                    .header(
+                        "X-Robots-Tag",
+                        "noindex, noarchive, nosnippet, noimageindex",
+                    ),
             )
             .wrap(middleware::Compress::new(COMPRESS))
             // regular MD@Home routes


### PR DESCRIPTION
- Use a custom 404 service because the default does not use SSL
- include an `X-Robots-Tag` header to curb crawlers from indexing tokenized pages