### PR TITLE
fix: Add timeouts to HTTP Clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,7 +1539,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "scalpel"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "actix-web",
  "async-trait",

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,6 +1,7 @@
 use crate::config::AppConfig;
 use crate::utils::constants as c;
 use std::sync::{Arc, RwLock, RwLockReadGuard};
+use std::time::Duration;
 
 // below are structures that represent JSON objects for passing messages to and from the server
 //
@@ -93,7 +94,12 @@ impl Backend {
     pub fn new(config: Arc<AppConfig>) -> Self {
         Self {
             config,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                // actual requests for this client should never exceed 60s,
+                // unless you have the worst internet connection in history
+                .timeout(Duration::from_secs(60))
+                .build()
+                .expect("backend http client"),
 
             upstream_url: RwLock::new(None),
             tls: RwLock::new(None),

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -112,6 +112,8 @@ lazy_static! {
     /// Lazily loaded HTTP Client that will be used for polling upstream for images.
     static ref HTTP_CLIENT: reqwest::Client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
+        // if a request exceeds 5 minutes, that's big yikes
+        .timeout(time::Duration::from_secs(300))
         .build()
         .expect("misconfigured lazy_static http client");
 }


### PR DESCRIPTION
A `5m` timeout was added to the HTTP Client in the `handler.rs` module.

A `1m` timeout was added to the HTTP Client in the `backend.rs` module.

Fixed #22