### PR TITLE
feat: Add prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
+
+[[package]]
 name = "async-trait"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1545,7 @@ name = "scalpel"
 version = "0.4.1"
 dependencies = [
  "actix-web",
+ "arc-swap",
  "async-trait",
  "bincode",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ openssl = "0.10.33"
 hex = "0.4.3"
 lazy_static = "1.4.0"
 mime = "0.3.16"
+arc-swap = "1.2.0"
 
 [dependencies.tokio]
 version = "1.4.0"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,6 +1,7 @@
 use crate::config::AppConfig;
 use crate::utils::constants as c;
-use std::sync::{Arc, RwLock, RwLockReadGuard};
+use arc_swap::ArcSwap;
+use std::sync::Arc;
 
 // below are structures that represent JSON objects for passing messages to and from the server
 //
@@ -41,7 +42,7 @@ pub struct TlsPayload {
 // that wouldn't make any sense
 impl std::fmt::Debug for TlsPayload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TLSPayload")
+        f.debug_struct("TlsPayload")
             .field("created_at", &self.created_at)
             .finish()
     }
@@ -76,13 +77,17 @@ impl std::fmt::Display for BackendError {
 }
 impl std::error::Error for BackendError {}
 
+#[derive(Debug)]
+struct PingStore {
+    tls: TlsPayload,
+    token_key: String,
+    upstream_url: Arc<String>,
+}
 pub struct Backend {
     config: Arc<AppConfig>,
     client: reqwest::Client,
 
-    upstream_url: RwLock<Option<String>>,
-    tls: RwLock<Option<TlsPayload>>,
-    token_key: RwLock<Option<String>>,
+    ping_info: ArcSwap<Option<PingStore>>,
 }
 
 impl Backend {
@@ -95,9 +100,7 @@ impl Backend {
             config,
             client: reqwest::Client::new(),
 
-            upstream_url: RwLock::new(None),
-            tls: RwLock::new(None),
-            token_key: RwLock::new(None),
+            ping_info: ArcSwap::from_pointee(None),
         }
     }
 
@@ -117,8 +120,12 @@ impl Backend {
     ) -> Result<(Option<TlsPayload>, Option<String>), Box<dyn std::error::Error>> {
         // structure JSON request using configuration
         let payload = {
-            // unlock RwLock to get the last created_at
-            let tls = self.tls.read().unwrap();
+            // find the tls_created_at field from the last ping info
+            let last_ping = self.ping_info.load();
+            let tls_created_at = last_ping
+                .as_ref()
+                .as_ref()
+                .map(|x| x.tls.created_at.clone());
 
             PingRequest {
                 secret: self.config.client_secret.clone(),
@@ -131,7 +138,7 @@ impl Backend {
                     .unwrap_or(0),
                 build_version: c::SPEC,
                 ip_address: self.config.external_ip.clone(),
-                tls_created_at: tls.as_ref().map(|x| x.created_at.clone()),
+                tls_created_at,
             }
         };
         log::debug!("sending ping payload to server: {:?}", &payload);
@@ -178,42 +185,39 @@ impl Backend {
         Ok((client_setup.tls, new_token_key))
     }
 
-    /// Updates the internal structures based on the OK response in [`ping`](Self::ping) with the
-    /// least reprocussions (i.e. only writing to `RwLock`s if necessary)
+    /// Updates the internal structures based on the OK response in [`ping`](Self::ping)
     ///
     /// Returns Some(token_key) if there is a new token key, otherwise None
     fn update_from_response(&self, res: &PingResponse) -> Option<String> {
-        // store new tls_created_at because the server has determined we're using an outdated
-        // version
-        if let Some(ref tls) = res.tls {
-            let mut inner = self.tls.write().unwrap();
-            *inner = Some(tls.clone());
-        }
+        let last_info = self.ping_info.load();
+        let last_info = Option::as_ref(&last_info);
 
-        // store new upstream url
-        // weird syntax because we need to drop read lock before locking for write
-        let update_upstream = {
-            let inner = self.upstream_url.read().unwrap();
-            inner.as_ref() != Some(&res.image_server)
+        // find whether or not we have a new token key
+        let new_token_key = match last_info {
+            Some(x) => x.token_key != res.token_key,
+            // if this is the initial ping, then we do have a new token key
+            _ => true,
         };
-        if update_upstream {
-            let mut inner = self.upstream_url.write().unwrap();
-            *inner = Some(res.image_server.clone());
-        }
 
-        // read comment above this for reasoning on weird syntax
-        let update_key = {
-            let inner = self.token_key.read().unwrap();
-            inner.as_ref() != Some(&res.token_key)
+        let info = PingStore {
+            // either use the new TlsPayload or the one from the previous ping
+            //
+            // this should only panic if there is no TlsPayload on the previous ping *and* this
+            // ping, which means there is a critical problem.
+            tls: res
+                .tls
+                .as_ref()
+                .or_else(|| last_info.map(|x| &x.tls))
+                .map(TlsPayload::clone)
+                .unwrap(),
+            token_key: res.token_key.clone(),
+            upstream_url: Arc::new(res.image_server.clone()),
         };
-        if update_key {
-            let mut inner = self.token_key.write().unwrap();
-            *inner = Some(res.token_key.clone());
+        self.ping_info.store(Arc::new(Some(info)));
 
-            // return inner token_key, signalling that this token key is a brand new one
-            inner.clone()
+        if new_token_key {
+            Some(res.token_key.clone())
         } else {
-            // we didn't update token key, so signal that the one stored internally is up-to-date
             None
         }
     }
@@ -252,7 +256,8 @@ impl Backend {
 
     /// Returns the upstream url stored from the API. Returns `None` if there has been no
     /// successful ping yet, and `Some` containing the upstream URL as provided up the API.
-    pub fn get_upstream(&self) -> RwLockReadGuard<Option<String>> {
-        self.upstream_url.read().unwrap()
+    pub fn get_upstream(&self) -> Option<Arc<String>> {
+        let ping_info = self.ping_info.load();
+        Option::as_ref(&ping_info).map(|x| Arc::clone(&x.upstream_url))
     }
 }

--- a/src/http/handler.rs
+++ b/src/http/handler.rs
@@ -152,10 +152,9 @@ async fn start_poll_upstream(
     use std::str::FromStr;
 
     let url = {
-        let upstream_guard = backend.get_upstream();
-        let upstream = upstream_guard.as_ref().ok_or(NoUpstreamError)?;
+        let upstream = backend.get_upstream().ok_or(NoUpstreamError)?;
 
-        let base_url = reqwest::Url::parse(upstream)?;
+        let base_url = reqwest::Url::parse(&upstream)?;
         reqwest::Url::options()
             .base_url(Some(&base_url))
             .parse(&format!(

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -131,7 +131,7 @@ fn spawn_http_server(
             .wrap(
                 middleware::DefaultHeaders::new()
                     // Advertisement Headers
-                    .header("Server", server_info.clone())
+                    .header("Server", &server_info)
                     .header("X-Powered-By", "Actix Web")
                     .header("X-Version", c::VERSION)
                     // Headers required by client spec
@@ -150,6 +150,9 @@ fn spawn_http_server(
             .route(
                 "/{archive_type}/{chap_hash}/{image}", // untokenized route
                 web::get().to(md_service),
+            )
+            .default_service(
+                web::route().to(|| HttpResponse::NotFound().body("no valid route found")),
             )
     })
     .keep_alive(gs.config.keep_alive)

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -139,7 +139,11 @@ fn spawn_http_server(
                     .header("Access-Control-Allow-Origin", "https://mangadex.org")
                     .header("Access-Control-Expose-Headers", "*")
                     .header("Cache-Control", "public, max-age=1209600")
-                    .header("Timing-Allow-Origin", "https://mangadex.org"),
+                    .header("Timing-Allow-Origin", "https://mangadex.org")
+                    .header(
+                        "X-Robots-Tag",
+                        "noindex, noarchive, nosnippet, noimageindex",
+                    ),
             )
             .wrap(middleware::Compress::new(COMPRESS))
             // regular MD@Home routes

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -55,12 +55,12 @@ async fn md_service(
     // verify the token provided in the request url if verify tokens is enabled
     if !gs.config.skip_tokens {
         // unlock verifier mutex
-        let v = gs.verifier.read().unwrap();
+        let verifier = gs.verifier.load();
 
         match path
             .token
             .as_ref()
-            .map(|token| v.verify_url_token(token, &path.chap_hash))
+            .map(|token| verifier.verify_url_token(token, &path.chap_hash))
         {
             // result is good, so bypass
             Some(Ok(_)) => {}

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -52,7 +52,12 @@ impl ResponseError for TokenError {
 
     fn status_code(&self) -> StatusCode {
         match self {
-            Self::TokenExpired => StatusCode::GONE,
+            // official spec codes
+            // https://gitlab.com/mangadex-pub/mangadex_at_home/-/wikis/Formal-Specification-for-Custom-Clients#token
+            Self::TokenExpired
+            | Self::InvalidChapterHash
+            | Self::DecryptFailed
+            | Self::InvalidBase64 => StatusCode::FORBIDDEN,
             _ => StatusCode::BAD_REQUEST,
         }
     }


### PR DESCRIPTION
Adds a prometheus metrics module that contains all metrics and an endpoint that will serialize the data. Endpoint is `/prometheus`.

See #9 for more info on the metrics that are included.

Fixes #9